### PR TITLE
Add support for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 1.  Define password in each /secrets file
 
-2.  to build and run the containers use:
-  - `make` for production
-  - `make dev` for development 
+2.  to build and run the containers use: `make`
 
 3.  Browser: https://ft-transcendence.com
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -5,9 +5,6 @@ up:
 	docker compose -f srcs/docker-compose.yml up
 	# docker compose -f srcs/docker-compose.yml up --detach
 
-dev:
-	ENVIRONMENT=development docker compose -f srcs/docker-compose.yml up --build
-
 stop:
 	docker compose -f srcs/docker-compose.yml stop
 

--- a/docker/srcs/.env
+++ b/docker/srcs/.env
@@ -1,3 +1,8 @@
 POSTGRES_USER=pguser
 POSTGRES_DB=pgdb
 # POSTGRES_PASSWORD=example
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG="1"
+
+ALLOWED_HOSTS = "localhost, 127.0.0.1, backend, ft-transcendence.com, 192.168.20.111"

--- a/docker/srcs/.env
+++ b/docker/srcs/.env
@@ -5,4 +5,5 @@ POSTGRES_DB=pgdb
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG="1"
 
-ALLOWED_HOSTS = "localhost, 127.0.0.1, backend, ft-transcendence.com, 192.168.20.111"
+# get local ip: `hostname -I | awk '{print $1}'`
+ALLOWED_HOSTS = "localhost, ft-transcendence.com, backend, ft-transcendence.com, 192.168.1.235"

--- a/docker/srcs/docker-compose.yml
+++ b/docker/srcs/docker-compose.yml
@@ -17,15 +17,16 @@ services:
       EMAIL_PASSWORD_FILE: /run/secrets/email_password
       POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
       DJANGO_SUPERUSER_FILE: /run/secrets/django_superuser_password
-      ENVIRONMENT: ${ENVIRONMENT:-production}
-    networks:
-      - transcendence
-    # ports:
-    #   - "8080:8000"
+      DJANGO_SECRET_KEY: /run/secrets/django_secret_key
     secrets:
       - django_superuser_password
       - email_password
       - postgres_password
+      - django_secret_key
+    networks:
+      - transcendence
+    # ports:
+    #   - "8080:8000"
     
   postgres:
     container_name: postgres
@@ -74,3 +75,5 @@ secrets:
     file: ../secrets/postgres_password.txt
   email_password:
     file: ../secrets/email_host_password.txt
+  django_secret_key:
+    file: ../secrets/django_secret_key.txt

--- a/docker/srcs/requirements/backend/Dockerfile
+++ b/docker/srcs/requirements/backend/Dockerfile
@@ -18,6 +18,3 @@ COPY tools/backend.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/backend.sh
 
 ENTRYPOINT ["/usr/local/bin/backend.sh"]
-
-CMD [ "python3", "manage.py", "runserver", "0.0.0.0:8000" ]
-# CMD [ "gunicorn", "--bind", "0.0.0.0:8000", "backend.wsgi" ]

--- a/docker/srcs/requirements/backend/Dockerfile
+++ b/docker/srcs/requirements/backend/Dockerfile
@@ -8,8 +8,6 @@ RUN apt install python3 -y && apt install python3-pip -y
 
 RUN rm /usr/lib/python*/EXTERNALLY-MANAGED
 
-ENV ENVIRONMENT=production
-
 COPY tools/requirements.txt transcendence/requirements.txt
 COPY tools/requirements-dev.txt transcendence/requirements-dev.txt
 

--- a/docker/srcs/requirements/backend/conf/backend/settings.py
+++ b/docker/srcs/requirements/backend/conf/backend/settings.py
@@ -71,20 +71,14 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-9t0$i4hjzqu_cm=1@q0_7cpzgziu-xiwkqyiv2trpdeg2wyw-x'
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY') # or "django-insecure-change-me"
 
-# TODO: CHANGE DEBUG
-# SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
-# DEBUG = False
+DEBUG = bool(int(os.environ.get('DEBUG', 0)))
 
 ALLOWED_HOSTS = [
-    "localhost",
-    ".127.0.0.1",
-    'backend',
-    "ft-transcendence.com",
-    '192.168.20.111',
-    ]
+	h.strip() for h in os.environ.get('ALLOWED_HOSTS', '').split(',')
+	if h.strip()
+]
 
 ALLOWED_REFERERS = [
     "https://ft-transcendence.com/",
@@ -189,7 +183,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = 'Europe/Lisbon'
 
 USE_I18N = True
 
@@ -230,7 +224,7 @@ REST_FRAMEWORK = {
 }
 
 # CORS_ALLOW_ALL_ORIGINS = True
-# CORS_ALLOW_CREDENTIALS = True
+# CORS_ALLOW_CREDENTIALS = True # This is necessary to allow the frontend to send cookies
 
 CORS_ALLOWED_ORIGINS = [
     'https://127.0.0.1',

--- a/docker/srcs/requirements/backend/conf/backend/settings.py
+++ b/docker/srcs/requirements/backend/conf/backend/settings.py
@@ -71,7 +71,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY') # or "django-insecure-change-me"
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY') or "django-insecure-change-me"
 
 DEBUG = bool(int(os.environ.get('DEBUG', 0)))
 

--- a/docker/srcs/requirements/backend/tools/backend.sh
+++ b/docker/srcs/requirements/backend/tools/backend.sh
@@ -25,4 +25,8 @@ python3 manage.py createsuperuser --username admin --email mail@mail.com --noinp
 
 echo "backend starting"
 
-exec "$@"
+if [ "$DEBUG" = "1" ]; then
+    exec python3 manage.py runserver 0.0.0.0:8000
+else
+    exec gunicorn --bind 0.0.0.0:8000 backend.wsgi
+fi

--- a/docker/srcs/requirements/backend/tools/backend.sh
+++ b/docker/srcs/requirements/backend/tools/backend.sh
@@ -2,9 +2,12 @@
 
 cd transcendence
 
-export DJANGO_SUPERUSER_PASSWORD=$(cat $DJANGO_SUPERUSER_FILE);
+export DJANGO_SUPERUSER_PASSWORD=$(cat $DJANGO_SUPERUSER_FILE)
+export DJANGO_SECRET_KEY=$(cat $DJANGO_SECRET_KEY)
+export EMAIL_PASSWORD=$(cat $EMAIL_PASSWORD_FILE)
+export POSTGRES_PASSWORD=$(cat $POSTGRES_PASSWORD_FILE)
 
-if [ "$ENVIRONMENT" = "development" ]; then
+if [ "$DEBUG" = "1" ]; then
     pip install -r requirements-dev.txt
 else
     pip install -r requirements.txt

--- a/docker/srcs/requirements/nginx/conf/default.conf
+++ b/docker/srcs/requirements/nginx/conf/default.conf
@@ -51,7 +51,7 @@ server {
 
     root /usr/share/nginx/frontend;
 
-    location /api/ { 
+    location /api/ {
         proxy_pass http://backend:8000/api/;
         proxy_http_version 1.1;
         proxy_set_header X-Forwarded-Proto https;

--- a/docker/srcs/requirements/nginx/conf/default.conf
+++ b/docker/srcs/requirements/nginx/conf/default.conf
@@ -1,6 +1,6 @@
 server {
 	listen 80 default_server;
-	return 444;
+	# return 444;
 }
 
 # http {


### PR DESCRIPTION
### Updates
- Now the environment variables are protected and detached from the `settings.py`. `ALLOWED_HOSTS` and `DEBUG` are in the .`env` and the others in the secrets file.
  - A way to access the project in production on the local network has been established.
    - To access the local network, it was necessary to remove `return 444` from the `nginx` settings. 
  - Project execution for production or development is in accordance with the DEBUG variable.

