### PR TITLE
Updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@
 
 all:
 	sudo sysctl -w vm.max_map_count=262144
-	docker compose up --build backend nginx postgres
-	# docker compose up -d --build backend nginx postgres
+	# docker compose up --build backend nginx postgres
+	docker compose up -d --build backend nginx postgres
 
 up:
 	# docker compose up

--- a/backend/srcs/backend/Dockerfile
+++ b/backend/srcs/backend/Dockerfile
@@ -1,10 +1,10 @@
 FROM debian:latest
 
-RUN apt update && apt upgrade -y
+RUN apt-get update && apt-get upgrade -y
 
 RUN mkdir transcendence
 
-RUN apt install python3 -y && apt install python3-pip -y
+RUN apt-get install python3 -y && apt-get install python3-pip -y
 
 RUN rm /usr/lib/python*/EXTERNALLY-MANAGED
 

--- a/backend/srcs/backend/conf/backend/settings.py
+++ b/backend/srcs/backend/conf/backend/settings.py
@@ -304,7 +304,7 @@ SECURE_PROXY_SSL_HEADER = True
 # TODO: JWT settings
 
 SIMPLE_JWT = {
-    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=60),
+    'ACCESS_TOKEN_LIFETIME': timedelta(minutes=180),
     'SLIDING_TOKEN_REFRESH_LIFETIME': timedelta(days=1),
     'SLIDING_TOKEN_LIFETIME': timedelta(days=30),
     'SLIDING_TOKEN_REFRESH_LIFETIME_LATE_USER': timedelta(days=1),


### PR DESCRIPTION
## Updates
- Dockerfile more safe
  - `apt-get` is more safe for dockerfile 
- refresh token more time
  - change to 3h 